### PR TITLE
correct the installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ This [Atom](https://atom.io/) package provides [Netbeans IDE](https://netbeans.o
 
 ## Installing
 
-Use the Atom package manager, which can be found in the Settings view or
-run `apm install netbeans-keybinder-atom` from the command line.
+Use the Atom package manager, which can be found in the Settings view and search for `netbeans-keymap` or
+run `apm install netbeans-keymap` from the command line.
 
 ## Supported keybindings
 


### PR DESCRIPTION
Changed  package name from netbeans-keybinder-atom  to netbeans-keymap
